### PR TITLE
Use terminal-notifier if it's already in the path

### DIFF
--- a/lib/synack/server.rb
+++ b/lib/synack/server.rb
@@ -7,12 +7,10 @@ module Synack
 
     DEFAULT_OPTIONS = {
       host: 'localhost',
-      port: 11113
+      port: 11113,
     }
 
     attr_reader :host, :port, :socket
-
-    # Class methods ================================================================================
 
     def self.start(options={})
       options = DEFAULT_OPTIONS.merge(options)
@@ -28,7 +26,15 @@ module Synack
       ::DRb.stop_service
     end
 
-    # Instance methods =============================================================================
+    def binary
+      binary = '/Applications/terminal-notifier.app/Contents/MacOS/terminal-notifier'
+      unless File.exists? binary
+        binary = `which "terminal-notifier"`
+        binary.chomp!
+        raise "terminal-notifier could not be found in path" unless $? == 0
+      end
+      binary
+    end
 
     def sanitize(message)
       message && message.gsub(/[^0-9A-z\.\-\'\, ]/, '_')
@@ -36,7 +42,8 @@ module Synack
 
     def say(message)
       puts message
-      system "/Applications/terminal-notifier.app/Contents/MacOS/terminal-notifier -message \"#{sanitize(message)}\""
+      STDERR.puts command = "#{self.binary} -message \"#{sanitize(message)}\""
+      system command
     end
 
   end

--- a/synack.gemspec
+++ b/synack.gemspec
@@ -68,5 +68,6 @@ Gem::Specification.new do |s|
     s.add_dependency(%q<shoulda>, [">= 0"])
     s.add_dependency(%q<simplecov>, [">= 0"])
   end
+  s.add_dependency "terminal-notifier"
 end
 


### PR DESCRIPTION
To make synack easier to use, I've added the terminal-notifier gem as a dependency. The server now detects where the executable is and uses it on each message. 

This should be refactored to do this only once when the server is started.
