### PR TITLE
Remove terminal-notifier absolute path.

### DIFF
--- a/lib/synack/server.rb
+++ b/lib/synack/server.rb
@@ -36,7 +36,7 @@ module Synack
 
     def say(message)
       puts message
-      system "/Applications/terminal-notifier.app/Contents/MacOS/terminal-notifier -message \"#{sanitize(message)}\""
+      system "terminal-notifier -message \"#{sanitize(message)}\""
     end
 
   end


### PR DESCRIPTION
Removed absolute path to terminal-notifier executable because it breaks when terminal-notifier has been installed using Rubygems.
